### PR TITLE
Add PySpark validation engine and SparkSQL prompt cheatsheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ generation stages.
 ```bash
 pixi run main generate-db -c params_config/generate_db/tpcds_spark_dev.toml
 pixi run main make-histograms -c params_config/histogram/tpcds_dev.toml
-pixi run main synthetic-queries -c params_config/synthetic_generation/tpcds_dev.toml
-pixi run main filter-synthetic -c params_config/filter/filter_tpcds_dev.toml
+pixi run main synthetic-queries -c params_config/synthetic_generation/tpcds_pyspark_dev.toml
+pixi run main filter-synthetic -c params_config/filter/filter_tpcds_pyspark_dev.toml
 pixi run main extensions-online -c params_config/extensions_online/tpcds_pyspark_dev.toml
 ```
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,21 @@ pixi run main extensions-online -c params_config/extensions_online/tpch_dev.toml
 pixi run main fix-transform -c params_config/fix_transform/tpch_ollama_dev.toml
 ```
 
+# PySpark toy example
+
+The PySpark validator requires a parquet directory in addition to the DuckDB
+database. Use `tpcds_spark_dev.toml` for `generate-db` to produce both.
+The DuckDB database is still needed for the histogram and synthetic query
+generation stages.
+
+```bash
+pixi run main generate-db -c params_config/generate_db/tpcds_spark_dev.toml
+pixi run main make-histograms -c params_config/histogram/tpcds_dev.toml
+pixi run main synthetic-queries -c params_config/synthetic_generation/tpcds_dev.toml
+pixi run main filter-synthetic -c params_config/filter/filter_tpcds_dev.toml
+pixi run main extensions-online -c params_config/extensions_online/tpcds_pyspark_dev.toml
+```
+
 
 # Authors and contact
 This project was made by Gabriel Lozano under the supervision of Yanlei Diao

--- a/docs/endpoints/extensions_batch.md
+++ b/docs/endpoints/extensions_batch.md
@@ -25,28 +25,34 @@ endpoint.
 
 - `provider` (str): `"openai"` for the batch endpoint.
 - `model` (str): The model name (e.g., `"gpt-4o-mini"`).
-- `batch_size` (int): Number of queries per batch submission.
-  Default is 100. OpenAI has a limit of 50,000 requests per batch.
-- `batch_poll_interval_seconds` (float): Seconds to sleep between polls
-  when waiting for a batch to complete. Default is 30.0.
-- `validator_engine` (str): The query validation engine to use. Supported
-  values: `"duckdb"` (default) or `"pyspark"`. When `"pyspark"`,
-  `database_path` must point to a parquet directory with structure
-  `database_path/table_name/data.parquet` (as produced by `generate-db`
-  with `parquet_path`).
-- `database_path` (str): The path to the database used for query validation.
-  When `validator_engine` is `"duckdb"`, this should be a `.duckdb` or `.db`
-  DuckDB database file. When `validator_engine` is `"pyspark"`, this should be
-  a parquet directory.
 - `total_queries` (int): The total number of queries to process.
   OpenAI requires a minimum of 100 requests per batch.
 - `retry` (int): Number of retry rounds for failed queries. Each retry
   round re-submits all failed queries as a new batch with the validation
   error appended to the conversation.
+- `batch_size` (int): Number of queries per batch submission.
+  Default is 100. OpenAI has a limit of 50,000 requests per batch.
+- `batch_poll_interval_seconds` (float): Seconds to sleep between polls
+  when waiting for a batch to complete. Default is 30.0.
+
+## Attributes llm_params.engine_params
+
+Engine-specific parameters that control how queries are validated and what
+context is provided to the LLM.
+
+- `database_path` (str): The path to the database used for query validation.
+  When `validator_engine` is `"duckdb"`, this should be a `.duckdb` or `.db`
+  DuckDB database file. When `validator_engine` is `"pyspark"`, this should be
+  a parquet directory (as produced by `generate-db` with `parquet_path`).
+- `validator_engine` (str): The query validation engine to use. Supported
+  values: `"duckdb"` (default) or `"pyspark"`. When `"pyspark"`,
+  `database_path` must point to a parquet directory with structure
+  `database_path/table_name/data.parquet` (as produced by `generate-db`
+  with `parquet_path`).
+- `validation_timeout_seconds` (float): Timeout for query validation with the
+  selected validator engine. Default is 20 seconds.
 - `schema_path` (str): Path to the schema file used in prompts.
 - `prompts_path` (str): Path to the TOML file containing prompts.
-- `duckdb_timeout_seconds` (float): Timeout for query validation with the
-  selected validator engine. Default is 20 seconds.
 - `function_examples_path` (str | None): Optional path to a TOML file
   containing SQL function examples (e.g.,
   `params_config/functions/standard_sql_functions.toml`). Default is None.

--- a/docs/endpoints/extensions_online.md
+++ b/docs/endpoints/extensions_online.md
@@ -38,14 +38,6 @@ environment variables.
 provider, you can see a list of available models in
 [https://ollama.com/library](https://ollama.com/library). This parameter
 is mandatory when `llm_extension` is set to true.
-- `validator_engine` (str): The query validation engine to use. Supported values:
-`"duckdb"` (default) or `"pyspark"`. When `"pyspark"`, `database_path` must
-point to a parquet directory with structure `database_path/table_name/data.parquet`
-(as produced by `generate-db` with `parquet_path`).
-- `database_path` (str): The path to the database used for query validation.
-When `validator_engine` is `"duckdb"`, this should be a `.duckdb` or `.db`
-duckdb database file. When `validator_engine` is `"pyspark"`, this should be a
-parquet directory (as produced by `generate-db` with `parquet_path`).
 - `total_queries` (int): The total number of queries to process with LLM. This
 is not the total number of queries produced since some cases may fail to
 generate a valid query.
@@ -53,13 +45,27 @@ generate a valid query.
 This means that everytime a prompt has an error, we take the DBMS error
 and send it back to the LLM for them to fix. Common errors are having
 a wrong column name, or syntax errors.
-- `schema_path` (str): The path to the schema used. Used to add it into 
-the basic prompts mention in the `prompts_path`. The file can be any
+
+## Attributes llm_params.engine_params
+
+Engine-specific parameters that control how queries are validated and what
+context is provided to the LLM.
+
+- `database_path` (str): The path to the database used for query validation.
+When `validator_engine` is `"duckdb"`, this should be a `.duckdb` or `.db`
+duckdb database file. When `validator_engine` is `"pyspark"`, this should be a
+parquet directory (as produced by `generate-db` with `parquet_path`).
+- `validator_engine` (str): The query validation engine to use. Supported values:
+`"duckdb"` (default) or `"pyspark"`. When `"pyspark"`, `database_path` must
+point to a parquet directory with structure `database_path/table_name/data.parquet`
+(as produced by `generate-db` with `parquet_path`).
+- `validation_timeout_seconds` (float): The timeout for query validation
+with the selected validator engine. Default is 20 seconds.
+- `schema_path` (str): The path to the schema used. Used to add it into
+the basic prompts mentioned in the `prompts_path`. The file can be any
 plain file, like a txt.
 - `prompts_path` (str): The path to the toml file that contains the prompts.
-the details on the toml file are below.
-- `duckdb_timeout_seconds` (float): The timeout time for query validation
-with the selected validator engine. By default is 20 seconds.
+The details on the toml file are below.
 - `function_examples_path` (str | None): Optional path to a TOML file
 containing SQL function examples (e.g.,
 `params_config/functions/standard_sql_functions.toml`). Default is None.

--- a/docs/endpoints/synthetic_generation.md
+++ b/docs/endpoints/synthetic_generation.md
@@ -29,7 +29,17 @@ each signature up to `max_queries_per_signature` queries.
 
 - `dataset` (str): The dataset to be used (TPCDS, TPCH). This information
 is needed to load the correct foreign-key/primary-key information.
-- `duckdb_database` (str): The path to the DuckDB database file.
+- `validation_database_path` (str): The path to the database used for query
+validation. When `validator_engine` is `"duckdb"` (default), this should be
+a `.duckdb` or `.db` DuckDB database file. When `validator_engine` is
+`"pyspark"`, this should be a parquet directory structured as
+`validation_database_path/table_name/data.parquet` (as produced by
+`generate-db` with `parquet_path`).
+- `validator_engine` (str): The query validation engine. Supported values:
+`"duckdb"` (default) or `"pyspark"`. Uses a persistent connection —
+no new process is spawned per query.
+- `validation_timeout_seconds` (float): Timeout per query validation.
+Default is 5.0 seconds.
 - `histogram_path` (str): The path to the histogram parquet file generated
 using the `make-histograms` endpoint.
 - `output_folder` (str): The folder to save the generated queries.

--- a/params_config/extensions_batch/tpcds_dev.toml
+++ b/params_config/extensions_batch/tpcds_dev.toml
@@ -8,9 +8,11 @@ provider = "openai"
 model = "gpt-4o-mini"
 batch_size = 100
 batch_poll_interval_seconds = 30.0
-database_path = "tmp/database_TPCDS_0.1.duckdb"
 retry = 1
 total_queries = 100
+
+[llm_params.engine_params]
+database_path = "tmp/database_TPCDS_0.1.duckdb"
 prompts_path = "params_config/prompts/basic_prompt.toml"
 schema_path = "params_config/schemas/dev.txt"
 function_examples_path = "params_config/functions/standard_sql_functions.toml"

--- a/params_config/extensions_online/tpcds_dev.toml
+++ b/params_config/extensions_online/tpcds_dev.toml
@@ -10,11 +10,13 @@ probability = 0.7
 [llm_params]
 provider = "ollama"
 model = "llama3:latest"
-database_path = "tmp/database_TPCDS_0.1.duckdb"
 retry = 0
 total_queries = 7
+
+[llm_params.engine_params]
+database_path = "tmp/database_TPCDS_0.1.duckdb"
+validator_engine = "duckdb"
 prompts_path = "params_config/prompts/basic_prompt.toml"
 schema_path = "params_config/schemas/dev.txt"
 function_examples_path = "params_config/functions/standard_sql_functions.toml"
 number_of_function_examples = 5
-validator_engine = "duckdb"

--- a/params_config/extensions_online/tpcds_dev_bedrock.toml
+++ b/params_config/extensions_online/tpcds_dev_bedrock.toml
@@ -6,9 +6,11 @@ destination_folder = "tmp/extended_queries_bedrock"
 [llm_params]
 provider = "bedrock"
 model = "anthropic.claude-3-haiku-20240307-v1:0"
-database_path = "tmp/database_TPCDS_0.1.duckdb"
 retry = 1
 total_queries = 7
+
+[llm_params.engine_params]
+database_path = "tmp/database_TPCDS_0.1.duckdb"
 prompts_path = "params_config/prompts/basic_prompt.toml"
 schema_path = "params_config/schemas/dev.txt"
 function_examples_path = "params_config/functions/standard_sql_functions.toml"

--- a/params_config/extensions_online/tpcds_dev_openai.toml
+++ b/params_config/extensions_online/tpcds_dev_openai.toml
@@ -6,9 +6,11 @@ destination_folder = "tmp/extended_queries_openai"
 [llm_params]
 provider = "openai"
 model = "gpt-4o-mini"
-database_path = "tmp/database_TPCDS_0.1.duckdb"
 retry = 1
 total_queries = 7
+
+[llm_params.engine_params]
+database_path = "tmp/database_TPCDS_0.1.duckdb"
 prompts_path = "params_config/prompts/basic_prompt.toml"
 schema_path = "params_config/schemas/dev.txt"
 function_examples_path = "params_config/functions/standard_sql_functions.toml"

--- a/params_config/extensions_online/tpcds_dev_openai_flex.toml
+++ b/params_config/extensions_online/tpcds_dev_openai_flex.toml
@@ -6,9 +6,11 @@ destination_folder = "tmp/extended_queries_openai_flex"
 [llm_params]
 provider = "openai-flex"
 model = "gpt-5-nano"
-database_path = "tmp/database_TPCDS_0.1.duckdb"
 retry = 1
 total_queries = 5
+
+[llm_params.engine_params]
+database_path = "tmp/database_TPCDS_0.1.duckdb"
 prompts_path = "params_config/prompts/standard_prompt.toml"
 schema_path = "params_config/schemas/tpcds.txt"
 function_examples_path = "params_config/functions/standard_sql_functions.toml"

--- a/params_config/extensions_online/tpcds_llama4.toml
+++ b/params_config/extensions_online/tpcds_llama4.toml
@@ -11,9 +11,11 @@ probability = 0.7
 [llm_params]
 provider = "ollama"
 model = "llama4:16x17b"
-database_path = "generated_data/TPCDS_100/database_test/TPCDS_0.1.duckdb"
 retry = 1
 total_queries = 10000
+
+[llm_params.engine_params]
+database_path = "generated_data/TPCDS_100/database_test/TPCDS_0.1.duckdb"
 prompts_path = "params_config/prompts/standard_prompt.toml"
 schema_path = "params_config/schemas/tpcds.txt"
 function_examples_path = "params_config/functions/standard_sql_functions.toml"

--- a/params_config/extensions_online/tpcds_pyspark.toml
+++ b/params_config/extensions_online/tpcds_pyspark.toml
@@ -1,0 +1,22 @@
+llm_extension = true
+union_extension = true
+queries_parquet = "tmp/filtered_queries_pyspark/filtered.parquet"
+destination_folder = "tmp/extended_queries_ollama_pyspark_dev"
+
+[union_params]
+max_queries = 5
+probability = 0.7
+
+[llm_params]
+provider = "ollama"
+model = "llama3:latest"
+retry = 1
+total_queries = 7
+
+[llm_params.engine_params]
+database_path = "tmp/database_parquet/TPCDS_0.1"
+validator_engine = "pyspark"
+prompts_path = "params_config/prompts/spark_prompt.toml"
+schema_path = "params_config/schemas/tpcds_spark.txt"
+function_examples_path = "params_config/functions/spark_functions.toml"
+number_of_function_examples = 5

--- a/params_config/extensions_online/tpcds_pyspark_dev.toml
+++ b/params_config/extensions_online/tpcds_pyspark_dev.toml
@@ -10,11 +10,13 @@ probability = 0.7
 [llm_params]
 provider = "ollama"
 model = "llama3:latest"
-database_path = "tmp/database_parquet/TPCDS_0.1"
 retry = 0
 total_queries = 7
+
+[llm_params.engine_params]
+database_path = "tmp/database_parquet/TPCDS_0.1"
+validator_engine = "pyspark"
 prompts_path = "params_config/prompts/standard_prompt.toml"
 schema_path = "params_config/schemas/tpcds_spark.txt"
 function_examples_path = "params_config/functions/spark_functions.toml"
 number_of_function_examples = 5
-validator_engine = "pyspark"

--- a/params_config/extensions_online/tpcds_pyspark_dev.toml
+++ b/params_config/extensions_online/tpcds_pyspark_dev.toml
@@ -1,7 +1,7 @@
 llm_extension = true
 union_extension = true
-queries_parquet = "tmp/filtered_queries/filtered.parquet"
-destination_folder = "tmp/extended_queries_ollama_pyspark"
+queries_parquet = "tmp/filtered_queries_pyspark/filtered.parquet"
+destination_folder = "tmp/extended_queries_ollama_pyspark_dev"
 
 [union_params]
 max_queries = 5
@@ -16,7 +16,7 @@ total_queries = 7
 [llm_params.engine_params]
 database_path = "tmp/database_parquet/TPCDS_0.1"
 validator_engine = "pyspark"
-prompts_path = "params_config/prompts/standard_prompt.toml"
-schema_path = "params_config/schemas/tpcds_spark.txt"
-function_examples_path = "params_config/functions/spark_functions.toml"
+prompts_path = "params_config/prompts/basic_prompt.toml"
+schema_path = "params_config/schemas/dev.txt"
+function_examples_path = "params_config/functions/minimal_example.toml"
 number_of_function_examples = 5

--- a/params_config/extensions_online/tpch_dev.toml
+++ b/params_config/extensions_online/tpch_dev.toml
@@ -11,9 +11,11 @@ probability = 0.7
 [llm_params]
 provider = "ollama"
 model = "llama3:latest"
-database_path = "generated_data/TPCH/database/TPCH_0.1.duckdb"
 retry = 1
 total_queries = 5
+
+[llm_params.engine_params]
+database_path = "generated_data/TPCH/database/TPCH_0.1.duckdb"
 prompts_path = "params_config/prompts/basic_prompt.toml"
 schema_path = "params_config/schemas/dev.txt"
 function_examples_path = "params_config/functions/standard_sql_functions.toml"

--- a/params_config/filter/filter_tpcds_pyspark_dev.toml
+++ b/params_config/filter/filter_tpcds_pyspark_dev.toml
@@ -1,0 +1,4 @@
+input_parquet = "tmp/synthetic_queries_pyspark/output.parquet"
+destination_folder = "tmp/filtered_queries_pyspark"
+empty_set = true
+stratified_sampling = false

--- a/params_config/generate_db/tpcds_spark_dev.toml
+++ b/params_config/generate_db/tpcds_spark_dev.toml
@@ -1,3 +1,4 @@
 dataset = "TPCDS"
 scale_factor = 0.1
 db_path = "tmp/database_TPCDS_0.1.duckdb"
+parquet_path = "tmp/database_parquet/TPCDS_0.1"

--- a/params_config/prompts/spark_prompt.toml
+++ b/params_config/prompts/spark_prompt.toml
@@ -1,0 +1,310 @@
+base_prompt = """
+You are a database expert. Now you are writing \
+queries to test your SQL engine on the TPCDS \
+dataset with challenging and diverse queries. You are \
+asked to extend each given query with new features, without \
+modifying the existing join structure or predicates, unless
+explicitly asked in future instructions. The resulting query \
+should not be trivial or equivalent to the input query.\
+When answering, return the query only in the markdown \
+format, for example:\
+```sql select * from table```
+The schema you will be using is the following:
+
+{schema}
+
+
+You will be using the SparkSQL engine. Here are some tips to take into account
+in this SQL dialect.
+
+## SparkSQL Rules
+
+### GROUP BY & Aggregation
+- Every non-aggregate column in SELECT must appear in GROUP BY.
+  - If the column is a dimension (string, id, flag): add it to GROUP BY.
+  - If the column is a measure (numeric fact): wrap it in an aggregate (MIN, MAX, SUM, AVG).
+- If any aggregate function (COUNT, SUM, AVG, etc.) appears in SELECT, a GROUP BY clause is required.
+- Inside ARRAY(...), all column references must be in GROUP BY or wrapped in an aggregate.
+  WRONG: ARRAY(col1, col2) with GROUP BY but col1 not a group key
+  RIGHT: ARRAY(MIN(col1), MIN(col2)) or add col1, col2 to GROUP BY
+
+### Window Functions
+- Window functions (OVER) alone do NOT require GROUP BY.
+- If the same SELECT has any aggregate function AND a window function, add GROUP BY.
+- In a query with GROUP BY, the window expression can only reference group keys or aggregates.
+  WRONG: SELECT col1, SUM(raw_col) OVER (...) FROM t GROUP BY col1  -- raw_col not a group key
+  RIGHT: SELECT col1, SUM(SUM(raw_col)) OVER (...) FROM t GROUP BY col1  -- inner SUM aggregates raw_col first, GROUP BY still required
+
+### JOIN Ordering
+- A table alias can only appear in a JOIN condition after that table has been introduced.
+  WRONG: FROM a JOIN b ON b.id = c.id JOIN c ON a.id = c.id  -- c.id used before c is joined
+  RIGHT: FROM a JOIN c ON a.id = c.id JOIN b ON b.id = c.id  -- join c first, then reference it
+- Subqueries in FROM always need an alias.
+
+### Type Safety
+- Use TRY_DIVIDE(a, b) instead of a / b — avoids DIVIDE_BY_ZERO errors.
+- Use TRY_CAST(x AS T) instead of CAST(x AS T) — tolerates invalid conversions.
+- DATE_ADD(date, n): n must be INT/SMALLINT/TINYINT — use CAST(col AS INT) if col is BIGINT.
+- ARRAY_UNION(a, b): both arrays must have the same element type — CAST to align.
+- Integer division (INT / INT) returns INT — use CAST(a AS DOUBLE) for fractional results.
+
+### Schema Discipline
+- Only use column names from the schema provided above. Do not invent column names.
+- Use IS NOT NULL guards in anti-join subqueries to avoid swallowing all rows when NULLs are present.
+
+"""
+
+
+[weighted_prompts.self_join]
+prompt = "Your task is extend this query to add a self-join while keeping the existing predicates"
+weight = 10
+
+[weighted_prompts.outer_join]
+prompt = "Your task is to modify one join to become an outer-join while keeping all other predicates"
+weight = 10
+
+[weighted_prompts.nested_join_in]
+prompt = """Your task is to take this query and add a nested subquery in the type of \
+    an IN nested subquery. Make sure that the nested subquery returns at least one  \
+    column so that the subquery needs to be computed everytime; \
+    otherwise it will just be a constant. Keep the existing predicates."""
+weight = 5
+
+[weighted_prompts.nested_join_exists]
+prompt = """Your task is to take this query and add a nested subquery in the type of \
+    an EXISTS nested subquery. Make sure that the nested subquery returns at least one  \
+    column so that the subquery needs to be computed everytime; \
+    otherwise it will just be a constant. Keep the existing predicates."""
+weight = 5
+
+[weighted_prompts.window_function]
+prompt = """Your task is to add a window function to this query. \
+    It must be done in a way that works in most SQL dialects. \
+    You should keep the predicates of the query mostly intact."""
+weight = 10
+
+[weighted_prompts.inequality_join]
+prompt = """Your task is to modify one join to make it an inequality join \
+    while keeping all other predicates of the given query."""
+weight = 10
+
+
+[weighted_prompts.recursive_query_simple]
+prompt = """For the given guery, choose a table and write a recursive query \
+    on that table. In this case, you can ignore the join structure and predicates \
+    in the input query. """
+weight = 5
+
+[weighted_prompts.recursive_query_complex]
+prompt = """Extend the given query with a new table that is computed from a  \
+    recursive construct. Try to keep existing join structure and predicates, while
+    adding the table computed from recursion. """
+weight = 5
+
+[weighted_prompts.edge_case]
+prompt = """Modify this query to make it interesting and elaborate.
+Incorporate obscure semantical corner cases and unusual or
+even bizarre SQL semantics. Don't include recursion. """
+weight = 20
+
+[weighted_prompts.semi_join]
+prompt = """
+Semi joins return rows from the left table that have at least one match
+in the right table. This is an example of a semijoin :
+```sql
+SELECT *
+FROM city_airport
+WHERE iata IN (SELECT iata FROM airport_names);
+```
+
+Modify this query to add a semijoin.
+"""
+weight = 5
+
+[weighted_prompts.antijoin]
+prompt = """Anti joins return rows from the left table that
+have no matches in the right table. This is an example of an
+antijoin:
+```sql
+SELECT *
+FROM city_airport
+WHERE iata NOT IN (SELECT iata FROM airport_names WHERE iata IS NOT NULL);
+```
+
+Modify this query to add an antijoin.
+"""
+weight = 5
+
+[weighted_prompts.group_by_1]
+prompt = """
+Your task is to add a group by clause to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 1.
+"""
+weight = 7
+
+
+[weighted_prompts.group_by_order_by_1]
+prompt = """
+Your task is to add a group by clause and an order by clause to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 1.
+"""
+weight = 3
+
+[weighted_prompts.group_by_rollup_1]
+prompt = """
+Your task is to add a group by clause with rollup to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 1.
+"""
+weight = 1
+
+
+[weighted_prompts.group_by_2]
+prompt = """
+Your task is to add a group by clause to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 2.
+"""
+weight = 7
+
+
+[weighted_prompts.group_by_order_by_2]
+prompt = """
+Your task is to add a group by clause and an order by clause to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 2.
+"""
+weight = 3
+
+[weighted_prompts.group_by_rollup_2]
+prompt = """
+Your task is to add a group by clause with rollup to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 2.
+"""
+weight = 1
+
+
+[weighted_prompts.group_by_3]
+prompt = """
+Your task is to add a group by clause to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 3.
+"""
+weight = 7
+
+
+[weighted_prompts.group_by_order_by_3]
+prompt = """
+Your task is to add a group by clause and an order by clause to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 3.
+"""
+weight = 3
+
+[weighted_prompts.group_by_rollup_3]
+prompt = """
+Your task is to add a group by clause with rollup to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 3.
+"""
+weight = 1
+
+
+[weighted_prompts.group_by_4]
+prompt = """
+Your task is to add a group by clause to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 4.
+"""
+weight = 4
+
+
+[weighted_prompts.group_by_order_by_4]
+prompt = """
+Your task is to add a group by clause and an order by clause to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 4.
+"""
+weight = 2
+
+[weighted_prompts.group_by_rollup_4]
+prompt = """
+Your task is to add a group by clause with rollup to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 4.
+"""
+weight = 1
+
+
+[weighted_prompts.group_by_6]
+prompt = """
+Your task is to add a group by clause to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 6.
+"""
+weight = 1
+
+
+[weighted_prompts.group_by_order_by_6]
+prompt = """
+Your task is to add a group by clause and an order by clause to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 6.
+"""
+weight = 1
+
+[weighted_prompts.group_by_rollup_6]
+prompt = """
+Your task is to add a group by clause with rollup to the query.
+Make sure that the attributes in the group by clause are included in
+the select clause as the group by key, but the aggregates in the
+select clause should be posed on other attributes.
+
+The group by clause size should be 6.
+"""
+weight = 1

--- a/params_config/synthetic_generation/tpcds.toml
+++ b/params_config/synthetic_generation/tpcds.toml
@@ -1,5 +1,5 @@
 dataset = "TPCDS"
-duckdb_database = "generated_data/TPCDS_100/database/TPCDS_100.duckdb"
+validation_database_path = "generated_data/TPCDS_100/database/TPCDS_100.duckdb"
 histogram_path = "generated_data/TPCDS_100/histograms/histogram.parquet"
 output_folder = "generated_data/TPCDS_100/synthetic_data/"
 

--- a/params_config/synthetic_generation/tpcds_pyspark_dev.toml
+++ b/params_config/synthetic_generation/tpcds_pyspark_dev.toml
@@ -1,7 +1,8 @@
 dataset = "TPCDS"
-validation_database_path = "tmp/database_TPCDS_0.1.duckdb"
+validation_database_path = "tmp/database_parquet/TPCDS_0.1"
+validator_engine = "pyspark"
 histogram_path = "tmp/histograms/histogram.parquet"
-output_folder = "tmp/synthetic_queries"
+output_folder = "tmp/synthetic_queries_pyspark"
 
 unique_joins = true
 max_signatures_per_fact_table = 1

--- a/params_config/synthetic_generation/tpch_dev.toml
+++ b/params_config/synthetic_generation/tpch_dev.toml
@@ -1,5 +1,5 @@
 dataset = "TPCH"
-duckdb_database = "generated_data/TPCH/database/TPCH_0.1.duckdb"
+validation_database_path = "generated_data/TPCH/database/TPCH_0.1.duckdb"
 histogram_path = "generated_data/TPCH/histograms/histogram.parquet"
 output_folder = "generated_data/TPCH/synthetic_data/"
 

--- a/src/query_generator/database_connection/duckdb_validation.py
+++ b/src/query_generator/database_connection/duckdb_validation.py
@@ -98,6 +98,7 @@ class DuckDBQueryExecutor(QueryValidator):
       timeout_seconds=timeout_seconds,
       limit_output_size=self.limit_output_size,
     )
+    self._persistent_con: duckdb.DuckDBPyConnection | None = None
 
   def _execute_with_timeout(
     self, query: str, description: str
@@ -171,3 +172,25 @@ class DuckDBQueryExecutor(QueryValidator):
       execution.exception,
     )
     return result, execution.timed_out
+
+  def get_synthetic_query_cardinality(self, query: str) -> int:
+    """Run a COUNT(*) query and return its scalar result.
+
+    Uses a persistent connection — no new process per call. Timeout via
+    threading.Timer + con.interrupt(). Returns -1 on error or timeout.
+    """
+    if self._persistent_con is None:
+      self._persistent_con = duckdb.connect(
+        database=self.database_path, read_only=True
+      )
+    timer = threading.Timer(
+      self.timeout_seconds, self._persistent_con.interrupt
+    )
+    timer.start()
+    try:
+      rows = self._persistent_con.execute(query).fetchall()
+      return int(rows[0][0]) if rows else -1
+    except Exception:
+      return -1
+    finally:
+      timer.cancel()

--- a/src/query_generator/database_connection/duckdb_validation.py
+++ b/src/query_generator/database_connection/duckdb_validation.py
@@ -190,7 +190,8 @@ class DuckDBQueryExecutor(QueryValidator):
     try:
       rows = self._persistent_con.execute(query).fetchall()
       return int(rows[0][0]) if rows else -1
-    except Exception:
+    except Exception as exc:
+      logger.debug("Cardinality query failed: %s | query: %s", exc, query)
       return -1
     finally:
       timer.cancel()

--- a/src/query_generator/database_connection/pyspark_validation.py
+++ b/src/query_generator/database_connection/pyspark_validation.py
@@ -1,6 +1,8 @@
 import logging
 import multiprocessing
 import os
+import threading
+import uuid
 from dataclasses import dataclass
 from multiprocessing import Queue
 from pathlib import Path
@@ -52,7 +54,9 @@ def _run_pyspark_query_worker(
         table.createOrReplaceTempView(table_dir.name)
 
     result_df = spark.sql(query)
-    rows = result_df.limit(params.limit_output_size).take(100)
+    rows = result_df.limit(params.limit_output_size).take(
+      params.limit_output_size
+    )
     row_tuples = [tuple(row) for row in rows]
     q.put(QueryExecution(result=row_tuples, exception=None, timed_out=False))
   except Exception as exc:
@@ -68,6 +72,21 @@ def _run_pyspark_query_worker(
   finally:
     if spark is not None:
       spark.stop()
+
+
+def _run_persistent_spark_query(
+  spark: SparkSession,
+  query: str,
+  job_group: str,
+  q: Queue,
+) -> None:
+  """Run a COUNT(*) query on a persistent SparkSession, put result in q."""
+  try:
+    spark.sparkContext.setJobGroup(job_group, query, interruptOnCancel=True)
+    rows = spark.sql(query).take(1)
+    q.put(int(rows[0][0]) if rows else -1)
+  except Exception:
+    q.put(-1)
 
 
 class PySparkQueryValidator(QueryValidator):
@@ -93,6 +112,7 @@ class PySparkQueryValidator(QueryValidator):
       timeout_seconds=timeout_seconds,
       limit_output_size=self.limit_output_size,
     )
+    self._spark: SparkSession | None = None
 
   def _execute_with_timeout(
     self, query: str, description: str
@@ -158,3 +178,40 @@ class PySparkQueryValidator(QueryValidator):
     result = len(execution.result) if execution.result is not None else None
     logger.debug("Query exception: %s", execution.exception)
     return result, execution.timed_out
+
+  def get_synthetic_query_cardinality(self, query: str) -> int:
+    """Run a COUNT(*) query and return its scalar result.
+
+    Uses a persistent SparkSession — no new process per call. Timeout via
+    Spark job group cancellation. Returns -1 on error or timeout.
+    """
+    if self._spark is None:
+      os.environ["SPARK_HOME"] = pyspark.__path__[0]
+      logging.getLogger("py4j").setLevel(logging.INFO)
+      self._spark = (
+        SparkSession.builder.master("local[*]")
+        .appName("query-validator")
+        .config("spark.ui.showConsoleProgress", "false")
+        .config("spark.log.level", "WARN")
+        .getOrCreate()
+      )
+      base = Path(self.parquet_path)
+      for table_dir in sorted(base.iterdir()):
+        if table_dir.is_dir():
+          table = self._spark.read.parquet(str(table_dir))
+          table.createOrReplaceTempView(table_dir.name)
+
+    job_group = str(uuid.uuid4())
+    q: Queue = Queue()
+    t = threading.Thread(
+      target=_run_persistent_spark_query,
+      args=(self._spark, query, job_group, q),
+      daemon=True,
+    )
+    t.start()
+    t.join(self.timeout_seconds)
+    if t.is_alive():
+      self._spark.sparkContext.cancelJobGroup(job_group)
+      t.join()
+      return -1
+    return q.get() if not q.empty() else -1

--- a/src/query_generator/database_connection/pyspark_validation.py
+++ b/src/query_generator/database_connection/pyspark_validation.py
@@ -85,7 +85,8 @@ def _run_persistent_spark_query(
     spark.sparkContext.setJobGroup(job_group, query, interruptOnCancel=True)
     rows = spark.sql(query).take(1)
     q.put(int(rows[0][0]) if rows else -1)
-  except Exception:
+  except Exception as exc:
+    logger.debug("Cardinality query failed: %s | query: %s", exc, query)
     q.put(-1)
 
 
@@ -213,5 +214,10 @@ class PySparkQueryValidator(QueryValidator):
     if t.is_alive():
       self._spark.sparkContext.cancelJobGroup(job_group)
       t.join()
+      logger.debug(
+        "Cardinality query timed out after %ss | query: %s",
+        self.timeout_seconds,
+        query,
+      )
       return -1
     return q.get() if not q.empty() else -1

--- a/src/query_generator/database_connection/query_validator_abc.py
+++ b/src/query_generator/database_connection/query_validator_abc.py
@@ -11,3 +11,11 @@ class QueryValidator(ABC):
   @abstractmethod
   def get_query_output_size(self, query: str) -> tuple[int | None, bool]:
     """Get query output row count. Returns (row_count_or_none, timed_out)."""
+
+  @abstractmethod
+  def get_synthetic_query_cardinality(self, query: str) -> int:
+    """Run a COUNT(*) query and return its scalar result.
+
+    Uses a persistent connection — no new process per call. Returns -1 on
+    error or timeout.
+    """

--- a/src/query_generator/extensions/batch_llm_extension.py
+++ b/src/query_generator/extensions/batch_llm_extension.py
@@ -252,9 +252,9 @@ def batch_llm_extension(
   random.seed(42)
   batch_client: BatchClient = OpenAIBatchClient()
   query_validator = build_query_validator(
-    database_path=llm_params.database_path,
-    validation_timeout_seconds=llm_params.validation_timeout_seconds,
-    validator_engine=llm_params.validator_engine,
+    database_path=llm_params.engine_params.database_path,
+    validation_timeout_seconds=llm_params.engine_params.validation_timeout_seconds,
+    validator_engine=llm_params.engine_params.validator_engine,
   )
 
   sampled_queries = get_random_queries(input_queries_base_path, llm_params)

--- a/src/query_generator/extensions/llm_extension.py
+++ b/src/query_generator/extensions/llm_extension.py
@@ -52,21 +52,24 @@ def get_random_queries(
   sql_files = sorted(queries_base_path.rglob("*.sql"))
   random_query_paths = random.choices(sql_files, k=llm_params.total_queries)
 
-  extension_types = list(llm_params.prompts.weighted_prompts.keys())
+  extension_types = list(
+    llm_params.engine_params.prompts.weighted_prompts.keys()
+  )
   weights = [
-    llm_params.prompts.weighted_prompts[e].weight for e in extension_types
+    llm_params.engine_params.prompts.weighted_prompts[e].weight
+    for e in extension_types
   ]
   selected_types = random.choices(
     extension_types, weights=weights, k=llm_params.total_queries
   )
 
   n = min(
-    llm_params.number_of_function_examples,
-    len(llm_params.function_examples),
+    llm_params.engine_params.number_of_function_examples,
+    len(llm_params.engine_params.function_examples),
   )
   selected_samples = [
-    random.sample(llm_params.function_examples, n)
-    if llm_params.function_examples
+    random.sample(llm_params.engine_params.function_examples, n)
+    if llm_params.engine_params.function_examples
     else []
     for _ in range(llm_params.total_queries)
   ]
@@ -114,7 +117,9 @@ def get_random_prompt(
 ) -> LLM_Message:
   """Build the LLM prompt. Pure function — no random calls."""
   function_text = format_function_examples(function_samples)
-  prompt_text = params.prompts.weighted_prompts[extension_type].prompt
+  prompt_text = params.engine_params.prompts.weighted_prompts[
+    extension_type
+  ].prompt
 
   user_content = f"""This is the query you will be modifying. \
 You can base yourself upon it:
@@ -131,7 +136,7 @@ Return only the modified query in ```sql ``` format.
 """
 
   return [
-    {"role": "system", "content": params.prompts.base_prompt},
+    {"role": "system", "content": params.engine_params.prompts.base_prompt},
     {"role": "user", "content": user_content},
   ]
 
@@ -322,9 +327,9 @@ def llm_extension(
   """
   random.seed(42)
   query_validator = build_query_validator(
-    database_path=llm_params.database_path,
-    validation_timeout_seconds=llm_params.validation_timeout_seconds,
-    validator_engine=llm_params.validator_engine,
+    database_path=llm_params.engine_params.database_path,
+    validation_timeout_seconds=llm_params.engine_params.validation_timeout_seconds,
+    validator_engine=llm_params.engine_params.validator_engine,
   )
 
   processor = QueryProcessor(

--- a/src/query_generator/main.py
+++ b/src/query_generator/main.py
@@ -5,6 +5,7 @@ from typing import Annotated
 import duckdb
 import typer
 
+from query_generator.database_connection.factory import build_query_validator
 from query_generator.duckdb_connection.setup import generate_db
 from query_generator.extensions.batch_llm_extension import batch_llm_extension
 from query_generator.extensions.fix_transform import fix_transform
@@ -170,10 +171,14 @@ def synthetic_queries(
     SyntheticQueriesEndpoint,
   )
   default_logger(params.output_folder, debug_file=debug)
-  con = duckdb.connect(database=params.duckdb_database, read_only=True)
+  validator = build_query_validator(
+    database_path=params.validation_database_path,
+    validation_timeout_seconds=params.validation_timeout_seconds,
+    validator_engine=params.validator_engine,
+  )
   generate_synthetic_queries(
     SyntheticQueriesParams(
-      con=con,
+      validator=validator,
       user_input=params,
     ),
   )

--- a/src/query_generator/synthetic_queries/synthetic_query_generator.py
+++ b/src/query_generator/synthetic_queries/synthetic_query_generator.py
@@ -1,14 +1,15 @@
 import logging
-import threading
 from dataclasses import dataclass
 from itertools import product
 from pathlib import Path
 from typing import Any
 
-import duckdb
 import polars as pl
 from tqdm import tqdm
 
+from query_generator.database_connection.query_validator_abc import (
+  QueryValidator,
+)
 from query_generator.synthetic_queries.query_builder import (
   QueryGenerator,
 )
@@ -29,30 +30,7 @@ logger = logging.getLogger(__name__)
 @dataclass
 class SyntheticQueriesParams:
   user_input: SyntheticQueriesEndpoint
-  con: duckdb.DuckDBPyConnection
-
-
-def get_result_from_duckdb(
-  query: str, con: duckdb.DuckDBPyConnection, timeout: float = 5.0
-) -> int:
-  did_timeout = False
-
-  def _interrupt() -> None:
-    nonlocal did_timeout
-    did_timeout = True
-    con.interrupt()
-
-  timer = threading.Timer(timeout, _interrupt)
-  timer.start()
-  try:
-    result = con.sql(query).fetchall()[0][0]
-    return int(result)
-  except duckdb.BinderException:
-    return -1
-  except duckdb.Error:
-    return -1
-  finally:
-    timer.cancel()
+  validator: QueryValidator
 
 
 def get_total_iterations(search_params: SyntheticQueriesEndpoint) -> int:
@@ -136,7 +114,9 @@ def generate_synthetic_queries(
       )
     )
     for query in query_generator.generate_queries():
-      selected_rows = get_result_from_duckdb(query.query, params.con)
+      selected_rows = params.validator.get_synthetic_query_cardinality(
+        query.query
+      )
       if selected_rows == -1:
         logger.error("Query generated was not valid.")
         logger.debug(f"Query generated:\n{query.query}")

--- a/src/query_generator/synthetic_queries/synthetic_query_generator.py
+++ b/src/query_generator/synthetic_queries/synthetic_query_generator.py
@@ -118,8 +118,7 @@ def generate_synthetic_queries(
         query.query
       )
       if selected_rows == -1:
-        logger.error("Query generated was not valid.")
-        logger.debug(f"Query generated:\n{query.query}")
+        logger.debug("Query skipped (validator returned -1):\n%s", query.query)
         continue  # invalid query
 
       relative_path = writer.write_query_to_batch(

--- a/src/query_generator/utils/params.py
+++ b/src/query_generator/utils/params.py
@@ -191,9 +191,12 @@ class SyntheticQueriesEndpoint:
   minimum_like_support_probability: list[float]
   or_probability: list[float]
   # Paths
-  duckdb_database: str
+  validation_database_path: str
   output_folder: str
   histogram_path: str
+  # Validator
+  validator_engine: ValidatorEngine = ValidatorEngine.DUCKDB
+  validation_timeout_seconds: float = 5.0
 
 
 @dataclass

--- a/src/query_generator/utils/params.py
+++ b/src/query_generator/utils/params.py
@@ -63,6 +63,7 @@ class LLMPrompts:
 class LLMEngineParams:
   """Engine specific parameters for LLM augmentation."""
 
+  database_path: str
   prompts_path: Path = field(converter=Path)
   schema_path: Path = field(converter=Path)
   prompts: LLMPrompts = field(init=False)
@@ -101,7 +102,6 @@ class LLMEngineParams:
 class LLMParams:
   """Params used for the LLM endpoint"""
 
-  database_path: str
   total_queries: int
   retry: int
   model: str

--- a/src/query_generator/utils/params.py
+++ b/src/query_generator/utils/params.py
@@ -60,22 +60,14 @@ class LLMPrompts:
 
 
 @define
-class LLMParams:
-  """Params used for the LLM endpoint"""
+class LLMEngineParams:
+  """Engine specific parameters for LLM augmentation."""
 
-  database_path: str
-  total_queries: int
-  retry: int
-  model: str
   prompts_path: Path = field(converter=Path)
   schema_path: Path = field(converter=Path)
   prompts: LLMPrompts = field(init=False)
-  provider: str = "ollama"
   validator_engine: ValidatorEngine = ValidatorEngine.DUCKDB
   validation_timeout_seconds: float = 20.0
-  statistics_parquet: str | None = None
-  batch_size: int = 100
-  batch_poll_interval_seconds: float = 30.0
   function_examples_path: Path | None = field(
     default=None, converter=lambda v: Path(v) if v is not None else None
   )
@@ -103,6 +95,21 @@ class LLMParams:
       if isinstance(subcategory, dict)
       for func_name, sql in subcategory.items()
     ]
+
+
+@define
+class LLMParams:
+  """Params used for the LLM endpoint"""
+
+  database_path: str
+  total_queries: int
+  retry: int
+  model: str
+  engine_params: LLMEngineParams
+  provider: str = "ollama"
+  statistics_parquet: str | None = None
+  batch_size: int = 100
+  batch_poll_interval_seconds: float = 30.0
 
 
 @dataclass

--- a/src/query_generator/utils/toml_examples.py
+++ b/src/query_generator/utils/toml_examples.py
@@ -34,10 +34,12 @@ probability = 0.7
 [llm_params]
 provider = "ollama"
 model = "deepseek-r1:1.5b"
-database_path = "data/duckdb/TPCDS/0.db"
-validator_engine = "duckdb"
 retry = 1
 total_queries = 5
+
+[llm_params.engine_params]
+database_path = "data/duckdb/TPCDS/0.db"
+validator_engine = "duckdb"
 prompts_path = "params_config/prompts/basic_prompt.toml"
 schema_path = "params_config/schemas/dev.txt"
 function_examples_path = "params_config/functions/standard_sql_functions.toml"
@@ -54,10 +56,12 @@ provider = "openai"
 model = "gpt-4o-mini"
 batch_size = 100
 batch_poll_interval_seconds = 30.0
-database_path = "tmp/database_TPCDS_0.1.duckdb"
-validator_engine = "duckdb"
 retry = 1
 total_queries = 100
+
+[llm_params.engine_params]
+database_path = "tmp/database_TPCDS_0.1.duckdb"
+validator_engine = "duckdb"
 prompts_path = "params_config/prompts/basic_prompt.toml"
 schema_path = "params_config/schemas/dev.txt"
 function_examples_path = "params_config/functions/standard_sql_functions.toml"

--- a/src/query_generator/utils/toml_examples.py
+++ b/src/query_generator/utils/toml_examples.py
@@ -81,7 +81,7 @@ weight = 2
 """,
   EndpointName.SYNTHETIC_GENERATION: """\
 dataset = "TPCDS"
-duckdb_database = "path/to/duckdb.db"
+validation_database_path = "path/to/duckdb.db"
 output_folder = "path/to/destination/"
 histogram_path = "path/to/histogram.parquet"
 

--- a/tests/documentation/test_toml.py
+++ b/tests/documentation/test_toml.py
@@ -61,6 +61,6 @@ def test_llm_params():
 surrounding it with ```sql Select from....```
 """
   assert (
-    params.llm_params.prompts.base_prompt.strip()
+    params.llm_params.engine_params.prompts.base_prompt.strip()
     == base_prompt_expected.strip()
   )

--- a/tests/documentation/test_toml.py
+++ b/tests/documentation/test_toml.py
@@ -41,11 +41,11 @@ def test_toml_files():
   """Test the example toml files provided"""
   base_path = Path(__file__).parent.parent.parent
   for endpoint_name in EndpointName:
-    docs_path = (base_path / "params_config" / endpoint_name).glob("*toml")
-    assert len(list(docs_path)) > 0
+    docs = list((base_path / "params_config" / endpoint_name).glob("*toml"))
+    assert len(docs) > 0
     # parse the docs and throw no errors in the process
-    for doc in docs_path:
-      params = read_and_parse_toml(doc.read_text(), mapping[endpoint_name])
+    for doc in docs:
+      params = read_and_parse_toml(doc, mapping[endpoint_name])
       assert params is not None
 
 

--- a/tests/duckdb/test_duckdb_utils.py
+++ b/tests/duckdb/test_duckdb_utils.py
@@ -11,8 +11,8 @@ from query_generator.duckdb_connection.utils import (
   get_null_count,
   DuckDBColumnInfo,
 )
-from query_generator.synthetic_queries.synthetic_query_generator import (
-  get_result_from_duckdb,
+from query_generator.database_connection.duckdb_validation import (
+  DuckDBQueryExecutor,
 )
 from query_generator.tools.histograms import DuckDBHistogramParser
 from query_generator.utils.definitions import Dataset
@@ -61,10 +61,9 @@ def test_null_values(duckdb_connection):
   """Test null counting for a column."""
   con = duckdb_connection
   column_info = DuckDBColumnInfo(con=con, table="item", column="i_rec_end_date")
-  expected = get_result_from_duckdb(
-    f"SELECT COUNT_IF({column_info.column} IS NULL) FROM {column_info.table}",
-    con,
-  )
+  expected = con.execute(
+    f"SELECT COUNT_IF({column_info.column} IS NULL) FROM {column_info.table}"
+  ).fetchall()[0][0]
 
   assert get_null_count(column_info) == expected
 
@@ -77,10 +76,13 @@ def test_null_values(duckdb_connection):
   ],
 )
 def test_duck_db_execution(query, expected_result, duckdb_connection):
-  """Test the execution of queries in DuckDB."""
-  # Setup DuckDB
-  con = duckdb_connection
-  val = get_result_from_duckdb(query, con)
+  """Test get_synthetic_query_cardinality on DuckDBQueryExecutor."""
+  executor = DuckDBQueryExecutor(
+    database_path=TEMP_DB_PATH, timeout_seconds=10.0
+  )
+  # Reuse the fixture's open connection to avoid a read-only/write conflict.
+  executor._persistent_con = duckdb_connection
+  val = executor.get_synthetic_query_cardinality(query)
   assert val == expected_result, f"Expected {expected_result}, but got {val}"
 
 

--- a/tests/integration/test_pyspark_validator.py
+++ b/tests/integration/test_pyspark_validator.py
@@ -1,0 +1,42 @@
+"""Integration tests for PySparkQueryValidator."""
+
+import pytest
+from pyspark.sql import SparkSession
+
+from query_generator.database_connection.pyspark_validation import (
+  PySparkQueryValidator,
+)
+from tests.integration.conftest import PARQUET_PATH
+
+
+@pytest.mark.integration
+def test_get_synthetic_query_cardinality(spark: SparkSession) -> None:
+  """PySparkQueryValidator.get_synthetic_query_cardinality returns correct COUNT(*)."""
+  validator = PySparkQueryValidator(
+    parquet_path=str(PARQUET_PATH),
+    timeout_seconds=30.0,
+  )
+  # Reuse the session fixture so no new JVM is spawned.
+  validator._spark = spark
+
+  result = validator.get_synthetic_query_cardinality(
+    "SELECT COUNT(*) FROM customer"
+  )
+  assert result == 10000, f"Expected 10000, got {result}"
+
+
+@pytest.mark.integration
+def test_get_synthetic_query_cardinality_returns_minus_one_on_error(
+  spark: SparkSession,
+) -> None:
+  """Returns -1 when the query is invalid."""
+  validator = PySparkQueryValidator(
+    parquet_path=str(PARQUET_PATH),
+    timeout_seconds=30.0,
+  )
+  validator._spark = spark
+
+  result = validator.get_synthetic_query_cardinality(
+    "SELECT COUNT(*) FROM nonexistent_table"
+  )
+  assert result == -1

--- a/tests/llm/test_batch_llm_extension.py
+++ b/tests/llm/test_batch_llm_extension.py
@@ -10,7 +10,7 @@ from query_generator.extensions.llm_clients import (
   BatchResult,
   OpenAIBatchClient,
 )
-from query_generator.utils.params import LLMParams
+from query_generator.utils.params import LLMEngineParams, LLMParams
 
 VALID_SQL = "SELECT 1"
 VALID_RESPONSE = f"```sql\n{VALID_SQL}\n```"
@@ -37,15 +37,17 @@ def _make_llm_params(
     / "dev.txt"
   )
   return LLMParams(
-    database_path=db_path,
     total_queries=total_queries,
     retry=retry,
     model="gpt-4o-mini",
     provider="openai",
-    prompts_path=str(prompts_path),
-    schema_path=str(schema_path),
     batch_size=batch_size,
     batch_poll_interval_seconds=0.01,
+    engine_params=LLMEngineParams(
+      database_path=db_path,
+      prompts_path=str(prompts_path),
+      schema_path=str(schema_path),
+    ),
   )
 
 

--- a/tests/llm/test_llm_clients.py
+++ b/tests/llm/test_llm_clients.py
@@ -13,7 +13,7 @@ from query_generator.extensions.llm_clients import (
   get_llm_client_factory,
 )
 from query_generator.extensions.llm_extension import llm_extension
-from query_generator.utils.params import LLMParams
+from query_generator.utils.params import LLMEngineParams, LLMParams
 
 VALID_SQL = "SELECT 1"
 VALID_RESPONSE = f"```sql\n{VALID_SQL}\n```"
@@ -39,13 +39,15 @@ def _make_llm_params(
     / "dev.txt"
   )
   return LLMParams(
-    database_path=db_path,
     total_queries=total_queries,
     retry=retry,
     model="gpt-4o-mini",
     provider="openai",
-    prompts_path=str(prompts_path),
-    schema_path=str(schema_path),
+    engine_params=LLMEngineParams(
+      database_path=db_path,
+      prompts_path=str(prompts_path),
+      schema_path=str(schema_path),
+    ),
   )
 
 

--- a/tests/llm/test_llm_extension.py
+++ b/tests/llm/test_llm_extension.py
@@ -19,7 +19,7 @@ from query_generator.extensions.llm_extension import (
   get_random_queries,
   llm_extension,
 )
-from query_generator.utils.params import LLMParams
+from query_generator.utils.params import LLMEngineParams, LLMParams
 
 VALID_SQL = "SELECT 1"
 VALID_RESPONSE = f"```sql\n{VALID_SQL}\n```"
@@ -46,12 +46,14 @@ def _make_llm_params(
     / "dev.txt"
   )
   return LLMParams(
-    database_path=db_path,
     total_queries=total_queries,
     retry=retry,
     model="llama3:latest",
-    prompts_path=str(prompts_path),
-    schema_path=str(schema_path),
+    engine_params=LLMEngineParams(
+      database_path=db_path,
+      prompts_path=str(prompts_path),
+      schema_path=str(schema_path),
+    ),
   )
 
 
@@ -232,24 +234,26 @@ def test_get_random_prompt_includes_function_examples(
   db_path = str(tmp_path / "test.duckdb")
   duckdb.connect(db_path).close()
   params = LLMParams(
-    database_path=db_path,
     total_queries=1,
     retry=0,
     model="test",
-    prompts_path=str(
-      Path(__file__).parent.parent.parent
-      / "params_config"
-      / "prompts"
-      / "basic_prompt.toml"
-    ),
-    schema_path=str(
-      Path(__file__).parent.parent.parent
-      / "params_config"
-      / "schemas"
-      / "dev.txt"
+    engine_params=LLMEngineParams(
+      database_path=db_path,
+      prompts_path=str(
+        Path(__file__).parent.parent.parent
+        / "params_config"
+        / "prompts"
+        / "basic_prompt.toml"
+      ),
+      schema_path=str(
+        Path(__file__).parent.parent.parent
+        / "params_config"
+        / "schemas"
+        / "dev.txt"
+      ),
     ),
   )
-  extension_types = list(params.prompts.weighted_prompts.keys())
+  extension_types = list(params.engine_params.prompts.weighted_prompts.keys())
   function_samples = [
     ("math.aggregate.SUM", "SELECT SUM(x) FROM t"),
     ("string.transform.UPPER", "SELECT UPPER(name) FROM t"),
@@ -275,24 +279,26 @@ def test_get_random_prompt_omits_function_section_when_empty(
   db_path = str(tmp_path / "test.duckdb")
   duckdb.connect(db_path).close()
   params = LLMParams(
-    database_path=db_path,
     total_queries=1,
     retry=0,
     model="test",
-    prompts_path=str(
-      Path(__file__).parent.parent.parent
-      / "params_config"
-      / "prompts"
-      / "basic_prompt.toml"
-    ),
-    schema_path=str(
-      Path(__file__).parent.parent.parent
-      / "params_config"
-      / "schemas"
-      / "dev.txt"
+    engine_params=LLMEngineParams(
+      database_path=db_path,
+      prompts_path=str(
+        Path(__file__).parent.parent.parent
+        / "params_config"
+        / "prompts"
+        / "basic_prompt.toml"
+      ),
+      schema_path=str(
+        Path(__file__).parent.parent.parent
+        / "params_config"
+        / "schemas"
+        / "dev.txt"
+      ),
     ),
   )
-  extension_types = list(params.prompts.weighted_prompts.keys())
+  extension_types = list(params.engine_params.prompts.weighted_prompts.keys())
   messages = get_random_prompt(params, "SELECT 1", extension_types[0], [])
   user_content = messages[1]["content"]
   assert "Add the following SQL functions" not in user_content
@@ -315,24 +321,26 @@ def test_get_random_queries_reproducible(tmp_path: Path) -> None:
     / "standard_sql_functions.toml"
   )
   params = LLMParams(
-    database_path=db_path,
     total_queries=10,
     retry=0,
     model="test",
-    prompts_path=str(
-      Path(__file__).parent.parent.parent
-      / "params_config"
-      / "prompts"
-      / "basic_prompt.toml"
+    engine_params=LLMEngineParams(
+      database_path=db_path,
+      prompts_path=str(
+        Path(__file__).parent.parent.parent
+        / "params_config"
+        / "prompts"
+        / "basic_prompt.toml"
+      ),
+      schema_path=str(
+        Path(__file__).parent.parent.parent
+        / "params_config"
+        / "schemas"
+        / "dev.txt"
+      ),
+      function_examples_path=str(function_examples_path),
+      number_of_function_examples=3,
     ),
-    schema_path=str(
-      Path(__file__).parent.parent.parent
-      / "params_config"
-      / "schemas"
-      / "dev.txt"
-    ),
-    function_examples_path=str(function_examples_path),
-    number_of_function_examples=3,
   )
 
   random.seed(42)
@@ -421,23 +429,25 @@ def test_pyspark_validator_with_mocked_llm(
   )
 
   params = LLMParams(
-    database_path=str(parquet_dir),
     total_queries=1,
     retry=0,
     model="test",
-    prompts_path=str(
-      Path(__file__).parent.parent.parent
-      / "params_config"
-      / "prompts"
-      / "basic_prompt.toml"
+    engine_params=LLMEngineParams(
+      database_path=str(parquet_dir),
+      prompts_path=str(
+        Path(__file__).parent.parent.parent
+        / "params_config"
+        / "prompts"
+        / "basic_prompt.toml"
+      ),
+      schema_path=str(
+        Path(__file__).parent.parent.parent
+        / "params_config"
+        / "schemas"
+        / "dev.txt"
+      ),
+      validator_engine="pyspark",
     ),
-    schema_path=str(
-      Path(__file__).parent.parent.parent
-      / "params_config"
-      / "schemas"
-      / "dev.txt"
-    ),
-    validator_engine="pyspark",
   )
   factory = LLMClientFactory(factory=OllamaLLMClient, init_kwargs={})
 

--- a/tests/query_generation/test_synthetic_queries.py
+++ b/tests/query_generation/test_synthetic_queries.py
@@ -1,5 +1,6 @@
 import tomllib
 from unittest import mock
+from unittest.mock import MagicMock
 
 import polars as pl
 import pytest
@@ -56,13 +57,12 @@ def test_cherry_pick(count_star, upper_bound, total_bins, expected_bin):
   ],
 )
 def test_binning_calls(extra_predicates, expected_call_count, unique_joins):
+  mock_validator = MagicMock()
+  mock_validator.get_synthetic_query_cardinality.return_value = 0
   with (
     mock.patch(
       "query_generator.synthetic_queries.utils.query_writer.Writer.write_query_to_batch"
     ) as mock_writer,
-    mock.patch(
-      "query_generator.synthetic_queries.synthetic_query_generator.get_result_from_duckdb"
-    ) as mock_connect,
     mock.patch(
       "query_generator.synthetic_queries.synthetic_query_generator.checkpoint_queries_parquet"
     ),
@@ -70,11 +70,10 @@ def test_binning_calls(extra_predicates, expected_call_count, unique_joins):
       "query_generator.synthetic_queries.utils.query_writer.Writer.write_toml"
     ),
   ):
-    mock_connect.return_value = 0
     data_toml = f"""
       dataset = "TPCDS"
       output_folder = ""
-      duckdb_database = ""
+      validation_database_path = ""
       dev = true
       max_hops = [1]
       extra_predicates = {extra_predicates}
@@ -99,7 +98,7 @@ def test_binning_calls(extra_predicates, expected_call_count, unique_joins):
     user_input = structure(tomllib.loads(data_toml), SyntheticQueriesEndpoint)
     generate_synthetic_queries(
       params=SyntheticQueriesParams(
-        con=None,
+        validator=mock_validator,
         user_input=user_input,
       ),
     )


### PR DESCRIPTION
## Summary

- Adds PySpark as a validation engine in the synthetic query pipeline (`pyspark_validation.py`, `duckdb_validation.py`, `synthetic_query_generator.py`)
- Adds new TOML configs for PySpark-based pipelines (`tpcds_pyspark.toml`, `tpcds_pyspark_dev.toml`, etc.)
- Adds a SparkSQL cheatsheet to `params_config/prompts/spark_prompt.toml` to reduce LLM query validation failures — covers GROUP BY/aggregation rules, window function + GROUP BY interaction, JOIN ordering, type safety (`TRY_DIVIDE`, `TRY_CAST`, `DATE_ADD` type requirements), and schema discipline
- Adds integration tests for PySpark validator

## Test plan

- [x] `pixi run test` passes
- [x] PySpark validation engine runs end-to-end with `tpcds_pyspark_dev.toml`
- [x] SparkSQL cheatsheet visible in rendered `base_prompt` via `pixi run python -c "import tomllib; print(tomllib.load(open('params_config/prompts/spark_prompt.toml','rb'))['base_prompt'])"`